### PR TITLE
Refactor configuration loading and struct definitions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,132 +2,66 @@ use rand::prelude::*;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
+#[serde(default)]
 pub struct Config {
-    #[serde(default = "default_theme")]
     pub theme: String,
-
-    #[serde(default = "default_seed")]
     pub seed: u64,
-
-    #[serde(default = "default_grid_width")]
     pub grid_width: u32,
-
-    #[serde(default = "default_grid_height")]
     pub grid_height: u32,
-
-    #[serde(default = "default_grid_scale")]
     pub grid_scale: u32,
-
-    #[serde(default = "default_corner_walls")]
     pub corner_walls: bool,
-
-    #[serde(default = "default_tick_length")]
     pub tick_length: f64,
-
-    #[serde(default = "default_food_ticks")]
     pub food_ticks: u32,
-
-    #[serde(default = "default_snake_spawn_segments")]
     pub snake_spawn_segments: u32,
-
-    #[serde(default = "default_snake_segment_despawn_interval")]
     pub snake_segment_despawn_interval: f64,
-
-    #[serde(default = "default_snake_respawn_delay")]
     pub snake_respawn_delay: f64,
-
-    #[serde(default = "default_eat_audio")]
     pub eat_audio: String,
-
-    #[serde(default = "default_destroy_audio")]
     pub destroy_audio: String,
-
-    #[serde(default = "default_spawn_food_audio")]
     pub spawn_food_audio: String,
-
-    #[serde(default = "default_spawn_snake_audio")]
     pub spawn_snake_audio: String,
 }
 
-fn default_theme() -> String {
-    String::from("dracula")
-}
-
-fn default_seed() -> u64 {
-    random()
-}
-
-fn default_grid_width() -> u32 {
-    17
-}
-
-fn default_grid_height() -> u32 {
-    13
-}
-
-fn default_grid_scale() -> u32 {
-    36
-}
-
-fn default_corner_walls() -> bool {
-    true
-}
-
-fn default_tick_length() -> f64 {
-    0.2
-}
-
-fn default_food_ticks() -> u32 {
-    16
-}
-
-fn default_snake_spawn_segments() -> u32 {
-    2
-}
-
-fn default_snake_segment_despawn_interval() -> f64 {
-    0.1
-}
-
-fn default_snake_respawn_delay() -> f64 {
-    0.5
-}
-
-fn default_eat_audio() -> String {
-    String::from("eat.mp3")
-}
-
-fn default_destroy_audio() -> String {
-    String::from("destroy.mp3")
-}
-
-fn default_spawn_food_audio() -> String {
-    String::from("spawn_food.mp3")
-}
-
-fn default_spawn_snake_audio() -> String {
-    String::from("spawn_snake.mp3")
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            theme: "dracula".into(),
+            seed: random(),
+            grid_width: 17,
+            grid_height: 13,
+            grid_scale: 36,
+            corner_walls: true,
+            tick_length: 0.2,
+            food_ticks: 16,
+            snake_spawn_segments: 2,
+            snake_segment_despawn_interval: 0.1,
+            snake_respawn_delay: 0.5,
+            eat_audio: "eat.mp3".into(),
+            destroy_audio: "destroy.mp3".into(),
+            spawn_food_audio: "spawn_food.mp3".into(),
+            spawn_snake_audio: "spawn_snake.mp3".into(),
+        }
+    }
 }
 
 #[derive(Deserialize)]
 pub struct Theme {
-    #[serde(default = "default_theme_color")]
     pub walls: String,
-
-    #[serde(default = "default_theme_color")]
     pub background: String,
-
-    #[serde(default = "default_theme_color")]
     pub snake: String,
-
-    #[serde(default = "default_theme_color_vec")]
     pub food: Vec<String>,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            walls: default_theme_color(),
+            background: default_theme_color(),
+            snake: default_theme_color(),
+            food: vec![default_theme_color()]
+        }
+    }
 }
 
 fn default_theme_color() -> String {
     String::from("ff00ff")
-}
-
-fn default_theme_color_vec() -> Vec<String> {
-    vec![default_theme_color()]
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ impl Default for Config {
 }
 
 #[derive(Deserialize)]
+#[serde(default)]
 pub struct Theme {
     pub walls: String,
     pub background: String,


### PR DESCRIPTION
Instead of using the reasonably-verbose Serde `default` attributes, consider using the `Default` trait.

### Pros

 - Works across the ecosystem, since `Default` is from the Rust core library;
 - Slightly less verbose, you don't have to define a function for every single field;
 - Allows you to generate a completely default value without relying on Serde, which I've done in main.
    - This means that the "missing config file" handling is a bit cleaner, since it can skip summoning Serde if the file doesn't exist.

### Cons
 - Technically it's a wee bit more allocation-happy since all defaults are generated at once and then replaced one by one by the values from the config file. But a few string allocations during startup is not the end of the world.
     - I haven't done this, but it could be fixed by making the configs non-owning, and using `&str` instead of `String`, that would mean holding onto the whole source string for the lifetime of the program though. Less allocations, but more memory usage (though since the config file isn't huge it's  not a big deal either)