### PR TITLE
don't segfault when process terminates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -326,12 +326,16 @@ fn snake_movement_input(
             continue;
         }
         for mut snake_head in snake_heads.iter_mut() {
-            let direction: Direction = match event.key_code.unwrap() {
-                KeyCode::Left => Direction::Left,
-                KeyCode::Down => Direction::Down,
-                KeyCode::Up => Direction::Up,
-                KeyCode::Right => Direction::Right,
-                _ => snake_head.direction,
+            let direction = if let Some(code) = event.key_code {
+                match code {
+                    KeyCode::Left => Direction::Left,
+                    KeyCode::Down => Direction::Down,
+                    KeyCode::Up => Direction::Up,
+                    KeyCode::Right => Direction::Right,
+                    _ => snake_head.direction,
+                }
+            } else {
+                continue
             };
             if direction != snake_head.direction.opposite() {
                 snake_head.next_direction = direction;


### PR DESCRIPTION
Hi :)

I'm not sure if you were able to reproduce this on your end, but when I kill the process the compiler throws:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/main.rs:329:61
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
zsh: segmentation fault (core dumped)  ./hebi
```

This PR should fix that.