### PR TITLE
Implemented control remapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_math",
  "bevy_utils",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ default-features = false
 features = [
   "bevy_audio",
   "bevy_wgpu",
+  "serialize",
   "render",
   # Default audio files are .wav,
   # but the mp3 feature is here in case the user wants to use mp3 files instead.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::{maps::*, Direction};
 
+use bevy::prelude::KeyCode;
 use rand::prelude::*;
 use rand_pcg::Pcg64;
 use serde::{Deserialize, Serialize, Serializer};
@@ -58,28 +59,27 @@ impl Default for Controls {
     fn default() -> Self {
         Self {
             up: vec![
-                Binding::Keyboard { code: 57416 }, // up arrow key
-                Binding::Keyboard { code: 17 }, // W
-                Binding::Keyboard { code: 37 }, // K
-                Binding::Keyboard { code: 72 }, // numpad up
+                Binding::Keyboard { key: KeyCode::Up },
+                Binding::Keyboard { key: KeyCode::W },
+                Binding::Keyboard { key: KeyCode::K },
+                Binding::Keyboard { key: KeyCode::Numpad8 }, // numpad up with num lock
             ],
             down: vec![
-                Binding::Keyboard { code: 57424 }, // down arrow key
-                Binding::Keyboard { code: 31 }, // S
-                Binding::Keyboard { code: 36 }, // J
-                Binding::Keyboard { code: 80 }, // numpad down
+                Binding::Keyboard { key: KeyCode::Down },
+                Binding::Keyboard { key: KeyCode::S },
+                Binding::Keyboard { key: KeyCode::J },
+                Binding::Keyboard { key: KeyCode::Numpad2 }, // numpad down with num lock
             ],
             left: vec![
-                Binding::Keyboard { code: 57419 }, // left arrow key
-                Binding::Keyboard { code: 30 }, // A
-                Binding::Keyboard { code: 35 }, // H
-                Binding::Keyboard { code: 75 }, // numpad left
+                Binding::Keyboard { key: KeyCode::Left },
+                Binding::Keyboard { key: KeyCode::A },
+                Binding::Keyboard { key: KeyCode::H },
             ],
             right: vec![
-                Binding::Keyboard { code: 57421 }, // right arrow key
-                Binding::Keyboard { code: 32 }, // D
-                Binding::Keyboard { code: 38 }, // L
-                Binding::Keyboard { code: 77 }, // numpad right
+                Binding::Keyboard { key: KeyCode::Right },
+                Binding::Keyboard { key: KeyCode::D },
+                Binding::Keyboard { key: KeyCode::L },
+                Binding::Keyboard { key: KeyCode::Numpad6 }, // numpad right with num lock
             ],
         }
     }
@@ -89,7 +89,7 @@ impl Default for Controls {
 #[serde(tag = "device")]
 pub enum Binding {
     #[serde(rename = "keyboard")]
-    Keyboard { code: u32 }
+    Keyboard { key: KeyCode }
 }
 
 #[derive(Clone, Serialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub theme: String,
     pub seed: u64,
     pub map: Box<dyn Map>,
+    pub controls: Controls,
     pub grid_scale: u32,
     pub tick_length: f64,
     pub food_ticks: u32,
@@ -29,6 +30,7 @@ impl Default for Config {
             theme: "dracula".into(),
             seed: random(),
             map: Box::new(DefaultMap::default()),
+            controls: Default::default(),
             grid_scale: 36,
             tick_length: 0.2,
             food_ticks: 16,
@@ -41,6 +43,53 @@ impl Default for Config {
             spawn_snake_audio: "spawn_snake.wav".into(),
         }
     }
+}
+
+#[derive(Deserialize)]
+#[serde(default)]
+pub struct Controls {
+    pub up: Vec<Binding>,
+    pub down: Vec<Binding>,
+    pub left: Vec<Binding>,
+    pub right: Vec<Binding>,
+}
+
+impl Default for Controls {
+    fn default() -> Self {
+        Self {
+            up: vec![
+                Binding::Keyboard { code: 57416 }, // up arrow key
+                Binding::Keyboard { code: 17 }, // W
+                Binding::Keyboard { code: 37 }, // K
+                Binding::Keyboard { code: 72 }, // numpad up
+            ],
+            down: vec![
+                Binding::Keyboard { code: 57424 }, // down arrow key
+                Binding::Keyboard { code: 31 }, // S
+                Binding::Keyboard { code: 36 }, // J
+                Binding::Keyboard { code: 80 }, // numpad down
+            ],
+            left: vec![
+                Binding::Keyboard { code: 57419 }, // left arrow key
+                Binding::Keyboard { code: 30 }, // A
+                Binding::Keyboard { code: 35 }, // H
+                Binding::Keyboard { code: 75 }, // numpad left
+            ],
+            right: vec![
+                Binding::Keyboard { code: 57421 }, // right arrow key
+                Binding::Keyboard { code: 32 }, // D
+                Binding::Keyboard { code: 38 }, // L
+                Binding::Keyboard { code: 77 }, // numpad right
+            ],
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "device")]
+pub enum Binding {
+    #[serde(rename = "keyboard")]
+    Keyboard { code: u32 }
 }
 
 #[derive(Clone, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use bevy::core::FixedTimestep;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::input::ElementState;
 use bevy::prelude::*;
+use bevy::utils::HashMap;
 use rand::prelude::*;
 use rand::seq::SliceRandom;
 use rand_pcg::Pcg64;
@@ -27,6 +28,49 @@ struct GridDimensions {
     width: u32,
     height: u32,
     scale: u32,
+}
+
+struct DirectionalControls {
+    scan_codes: HashMap<u32, Direction>,
+}
+
+impl DirectionalControls {
+    fn from_keyboard(&self, event: &KeyboardInput) -> Option<Direction> {
+        self.scan_codes
+            .get(&event.scan_code)
+            .cloned()
+    }
+}
+
+impl FromWorld for DirectionalControls {
+    fn from_world(world: &mut World) -> Self {
+        let config = world
+            .get_non_send_resource::<Config>()
+            .expect("Missing configuration from which to create control mapping");
+
+        let mut result = Self {
+            scan_codes: Default::default(),
+        };
+
+        let by_direction = [
+            (Direction::Up, &config.controls.up),
+            (Direction::Down, &config.controls.down),
+            (Direction::Left, &config.controls.left),
+            (Direction::Right, &config.controls.right),
+        ];
+
+        for (direction, bindings) in by_direction {
+            for binding in bindings {
+                match binding {
+                    Binding::Keyboard { code } => {
+                        result.scan_codes.insert(*code, direction);
+                    }
+                }
+            }
+        }
+
+        result
+    }
 }
 
 struct Random {
@@ -116,6 +160,7 @@ fn main() {
             height: grid_height,
             scale: grid_scale,
         })
+        .init_resource::<DirectionalControls>()
         .add_event::<RespawnEvent>()
         .add_plugins(DefaultPlugins)
         .run();
@@ -320,26 +365,25 @@ fn snake_spawn(
 fn snake_movement_input(
     mut keyboard_input_reader: EventReader<KeyboardInput>,
     mut snake_heads: Query<&mut SnakeHead>,
+    controls: Res<DirectionalControls>,
 ) {
+    let mut direction = None;
+
     for event in keyboard_input_reader.iter() {
         if event.state == ElementState::Released {
             continue;
         }
+
+        direction = controls.from_keyboard(event).or(direction);
+    }
+
+    if let Some(direction) = direction {
         for mut snake_head in snake_heads.iter_mut() {
-            let direction = if let Some(code) = event.key_code {
-                match code {
-                    KeyCode::Left | KeyCode::H | KeyCode::Numpad4 | KeyCode::A => Direction::Left,
-                    KeyCode::Down | KeyCode::J | KeyCode::Numpad2 | KeyCode::S => Direction::Down,
-                    KeyCode::Up | KeyCode::K | KeyCode::Numpad8 | KeyCode::W => Direction::Up,
-                    KeyCode::Right | KeyCode::L | KeyCode::Numpad6 | KeyCode::D => Direction::Right,
-                    _ => snake_head.direction,
-                }
-            } else {
+            if direction == snake_head.direction.opposite() {
                 continue;
-            };
-            if direction != snake_head.direction.opposite() {
-                snake_head.next_direction = direction;
             }
+
+            snake_head.next_direction = direction;
         }
     }
 }
@@ -491,7 +535,7 @@ struct Respawn {
 
 struct RespawnEvent;
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Direction {
     Left,
     Right,

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,13 +31,13 @@ struct GridDimensions {
 }
 
 struct DirectionalControls {
-    scan_codes: HashMap<u32, Direction>,
+    scan_codes: HashMap<KeyCode, Direction>,
 }
 
 impl DirectionalControls {
     fn from_keyboard(&self, event: &KeyboardInput) -> Option<Direction> {
-        self.scan_codes
-            .get(&event.scan_code)
+        event.key_code
+            .and_then(|code| self.scan_codes.get(&code))
             .cloned()
     }
 }
@@ -62,8 +62,8 @@ impl FromWorld for DirectionalControls {
         for (direction, bindings) in by_direction {
             for binding in bindings {
                 match binding {
-                    Binding::Keyboard { code } => {
-                        result.scan_codes.insert(*code, direction);
+                    Binding::Keyboard { key } => {
+                        result.scan_codes.insert(*key, direction);
                     }
                 }
             }


### PR DESCRIPTION
Closes #16.

## Changes

To do this, I added a new section to the `Config`, which can take an array of input bindings for each command in the game.

Since the convenient way to write this down in configuration is not strikingly efficient for runtime querying, I created a new resource type `DirectionalControls` that simplifies runtime access.

Refactored the `snake_movement_input` system to use this new resource, and cleaned up a bit of its code too, by breaking up the nesting in iteration. While it technically runs faster when the player presses multiple keys in one frame, it was unlikely to be a problem, so this was mainly a readability change. This way it is also a bit easier to add different event-reading loops later.

## Usage

Players can change their control configuration like this (likewise for `down`, `left`, `right`):
```toml
[controls]
up = [ { device = "keyboard", code = 72 } ]
```
Sadly, Bevy does not provide conversions from named keys to string and vice-versa, so I had to use their scan codes instead. Good part is that it's keyboard-layout dependent, bad part is that it is rather obscure to set up (I found them by putting a print on key presses and taking note of the codes for each key).

## Extensibility

When time comes for #17, the following changes will be needed:

 1. Add a new variant to the `config::Binding` enum with appropriate data;
 2. Consume those variants when constructing `DirectionalControls` (the compiler will yell the location at you);
 3. Add a new method to the `impl DirectionalControls` to read the gamepad event;
 4. Call that method in the input system within the processing loop for gamepads.